### PR TITLE
Fixing paths for Windows web servers

### DIFF
--- a/web/files/index.php
+++ b/web/files/index.php
@@ -10,7 +10,9 @@ function dirToArray($dir) {
             $hash = hash_file('sha1', $dir . "/" . $value);
             $size = filesize($dir . "/" . $value);
             $path = str_replace("files/", "", $dir . "/" . $value);
+            $path = str_replace("\\", "/", $path);
             $url = "http://" . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] . $dir . "/" . $value;
+            $url = str_replace("\\", "/", $url);
             if (strpos($path, "libraries") !== false) {
                $type = "LIBRARY";
             } else if (strpos($path, "mods") !== false) {


### PR DESCRIPTION
Hello,
Avec un serveur local Laragon sur Windows, les paths des fichiers sont parser avec des `\` ce qui fait péter le echo qui rajoute la ligne par fichier et corrompt le JSON final.
Ce commit permet de fix ça.